### PR TITLE
Made FiltersPage text readable on SuruDark theme

### DIFF
--- a/po/wallpapers.eder.pot
+++ b/po/wallpapers.eder.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wallpapers.eder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-24 08:01+0000\n"
+"POT-Creation-Date: 2021-02-14 16:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Featured"
 msgstr ""
 
-#: ../qml/ui/FiltersPage.qml:273 ../qml/ui/FiltersPage.qml:345
+#: ../qml/ui/FiltersPage.qml:274 ../qml/ui/FiltersPage.qml:346
 msgid "Sort by"
 msgstr ""
 
-#: ../qml/ui/FiltersPage.qml:313 ../qml/ui/FiltersPage.qml:370
+#: ../qml/ui/FiltersPage.qml:314 ../qml/ui/FiltersPage.qml:371
 msgid "Resolution"
 msgstr ""
 

--- a/qml/ui/FiltersPage.qml
+++ b/qml/ui/FiltersPage.qml
@@ -170,6 +170,7 @@ Page {
 
                     Text {
                         text: all ? i18n.tr("All") : (featured ? i18n.tr("Featured") : phObj.name)
+                        color: theme.palette.normal.backgroundText
                     }
                 }
 


### PR DESCRIPTION
The filters were black text on a black background in SuruDark theme.  Changed to white text in SuruDark theme and black text in Ambiance theme